### PR TITLE
Redirect legacy pages to current routes

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,67 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Recipe Organizer – Dashboard</title>
-    <link rel="stylesheet" href="styles.css" />
-  </head>
-  <body data-page="dashboard">
-    <header>
-      <div class="header-content">
-        <h1>Recipe Organizer</h1>
-        <div class="user-info">
-          <span id="userDisplayName"></span>
-          <button id="logoutButton" class="logout">Log Out</button>
-        </div>
-      </div>
-    </header>
-    <main class="container dashboard">
-      <section>
-        <h2>Add New Recipe</h2>
-        <form id="recipeForm">
-          <div class="form-group">
-            <label for="recipe-url">Recipe URL</label>
-            <!-- Wrap the input and extract button so they sit on the same row on wide screens -->
-            <div style="display:flex; gap:0.5rem; flex-wrap:wrap; align-items:center;">
-              <input type="url" id="recipe-url" name="url" placeholder="https://example.com/my-favourite-recipe" style="flex:1 1 auto;" required />
-              <button type="button" id="extractButton" class="btn btn-secondary" style="flex:0 0 auto;">Extract</button>
-            </div>
-            <small style="display:block; margin-top:0.25rem; font-size:0.75rem; color:#666;">Use the Extract button to automatically fill in the title, ingredients and steps from the URL.</small>
-          </div>
-          <div class="form-group">
-            <label for="recipe-title">Recipe Title</label>
-            <input type="text" id="recipe-title" name="title" placeholder="Chocolate Cake" required />
-          </div>
-          <div class="form-group">
-            <label for="recipe-ingredients">Ingredients (one per line)</label>
-            <textarea id="recipe-ingredients" name="ingredients" placeholder="e.g. 1 cup flour\n2 eggs\n1/2 cup sugar" required></textarea>
-          </div>
-          <div class="form-group">
-            <label for="recipe-steps">Steps (summary of instructions)</label>
-            <textarea id="recipe-steps" name="steps" placeholder="Summarize the cooking process here..." required></textarea>
-          </div>
-          <div class="form-group">
-            <label for="recipe-tags">Tags (comma separated)</label>
-            <input type="text" id="recipe-tags" name="tags" placeholder="dessert, easy, chocolate" />
-          </div>
-          <div class="form-group">
-            <label for="recipe-image">Recipe Image (optional)</label>
-            <input type="file" id="recipe-image" name="image" accept="image/*" />
-          </div>
-          <button type="submit" class="btn">Add Recipe</button>
-        </form>
-      </section>
-      <section>
-        <h2>Your Recipes</h2>
-        <div class="filter-section">
-          <input type="text" id="filterInput" placeholder="Filter by tag or title..." />
-          <button id="clearFilter" class="clear-filter">Clear filter</button>
-        </div>
-        <ul id="recipesList" class="recipe-list"></ul>
-      </section>
-    </main>
-    <script src="script.js"></script>
-  </body>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=add.html">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>If you are not redirected automatically, <a href="add.html">go to the recipe editor</a>.</p>
+</body>
 </html>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1,34 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Recipe Organizer – Home</title>
-    <link rel="stylesheet" href="styles.css" />
-  </head>
-  <body data-page="home">
-    <header>
-      <div class="header-content">
-        <h1><a href="home.html">Recipe Organizer</a></h1>
-        <nav class="nav-links">
-          <a href="add.html">Add Recipe</a>
-          <a href="view.html">View Recipes</a>
-        </nav>
-        <div class="user-info">
-          <span id="userDisplayName"></span>
-          <button id="logoutButton" class="logout">Log Out</button>
-        </div>
-      </div>
-    </header>
-    <main class="container home-content">
-      <h2>Welcome to your recipe collection</h2>
-      <p>Choose what you’d like to do:</p>
-      <div class="home-options">
-        <a href="add.html" class="home-option">Add a Recipe</a>
-        <a href="view.html" class="home-option">View Recipes</a>
-      </div>
-    </main>
-    <script src="script.js"></script>
-  </body>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=index.html">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>If you are not redirected automatically, <a href="index.html">click here</a>.</p>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- Redirect `home.html` to the current homepage so the sign-in link is reachable
- Redirect old `dashboard.html` to the add recipe page, avoiding a missing extractor UI

## Testing
- `python -m py_compile backend/extract_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3e0e500088323a9ba7bcfb459aac5