### PR TITLE
Restore legacy pages and improve extractor

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,67 +1,58 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Recipe Organizer – Dashboard</title>
-    <link rel="stylesheet" href="styles.css" />
-  </head>
-  <body data-page="dashboard">
-    <header>
-      <div class="header-content">
-        <h1>Recipe Organizer</h1>
-        <div class="user-info">
-          <span id="userDisplayName"></span>
-          <button id="logoutButton" class="logout">Log Out</button>
-        </div>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Add Recipe - Cocinando.Life</title>
+  <link rel="icon" type="image/png" href="icon.png">
+  <link rel="stylesheet" href="styles.css">
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <script defer src="script.js"></script>
+</head>
+<body data-page="add">
+  <header>
+    <nav class="navbar">
+      <div class="nav-left">
+        <a href="index.html" class="brand">
+          <img src="icon.png" alt="Cocinando.Life logo" class="logo">
+          <span>Cocinando.Life</span>
+        </a>
       </div>
-    </header>
-    <main class="container dashboard">
-      <section>
-        <h2>Add New Recipe</h2>
-        <form id="recipeForm">
-          <div class="form-group">
-            <label for="recipe-url">Recipe URL</label>
-            <!-- Wrap the input and extract button so they sit on the same row on wide screens -->
-            <div style="display:flex; gap:0.5rem; flex-wrap:wrap; align-items:center;">
-              <input type="url" id="recipe-url" name="url" placeholder="https://example.com/my-favourite-recipe" style="flex:1 1 auto;" required />
-              <button type="button" id="extractButton" class="btn btn-secondary" style="flex:0 0 auto;">Extract</button>
-            </div>
-            <small style="display:block; margin-top:0.25rem; font-size:0.75rem; color:#666;">Use the Extract button to automatically fill in the title, ingredients and steps from the URL.</small>
-          </div>
-          <div class="form-group">
-            <label for="recipe-title">Recipe Title</label>
-            <input type="text" id="recipe-title" name="title" placeholder="Chocolate Cake" required />
-          </div>
-          <div class="form-group">
-            <label for="recipe-ingredients">Ingredients (one per line)</label>
-            <textarea id="recipe-ingredients" name="ingredients" placeholder="e.g. 1 cup flour\n2 eggs\n1/2 cup sugar" required></textarea>
-          </div>
-          <div class="form-group">
-            <label for="recipe-steps">Steps (summary of instructions)</label>
-            <textarea id="recipe-steps" name="steps" placeholder="Summarize the cooking process here..." required></textarea>
-          </div>
-          <div class="form-group">
-            <label for="recipe-tags">Tags (comma separated)</label>
-            <input type="text" id="recipe-tags" name="tags" placeholder="dessert, easy, chocolate" />
-          </div>
-          <div class="form-group">
-            <label for="recipe-image">Recipe Image (optional)</label>
-            <input type="file" id="recipe-image" name="image" accept="image/*" />
-          </div>
-          <button type="submit" class="btn">Add Recipe</button>
-        </form>
-      </section>
-      <section>
-        <h2>Your Recipes</h2>
-        <div class="filter-section">
-          <input type="text" id="filterInput" placeholder="Filter by tag or title..." />
-          <button id="clearFilter" class="clear-filter">Clear filter</button>
-        </div>
-        <ul id="recipesList" class="recipe-list"></ul>
-      </section>
-    </main>
-    <script src="script.js"></script>
-  </body>
+      <ul class="nav-links">
+        <li><a href="add.html" id="nav-add" class="active">Add Recipe</a></li>
+        <li><a href="view.html" id="nav-view">View Recipes</a></li>
+      </ul>
+      <div class="user-menu" id="user-menu">
+        <!-- Populated by script.js -->
+      </div>
+    </nav>
+  </header>
+  <main class="content-container">
+    <h1 class="page-title">Add a New Recipe</h1>
+    <form id="add-recipe-form" class="recipe-form">
+      <label for="recipe-url">Recipe URL</label>
+      <div class="url-input-row">
+      <input type="url" id="recipe-url" placeholder="Enter recipe URL">
+        <button type="button" id="extract-btn" class="btn-secondary">Extract</button>
+      </div>
+      <label for="recipe-title">Title</label>
+      <input type="text" id="recipe-title" placeholder="Recipe title" required>
+      <label for="recipe-source">Source</label>
+      <input type="text" id="recipe-source" placeholder="Source (e.g. YouTube, Allrecipes)" readonly>
+      <label for="recipe-date">Date Added</label>
+      <input type="text" id="recipe-date" placeholder="Date" readonly>
+      <label for="recipe-ingredients">Ingredients (one per line)</label>
+      <textarea id="recipe-ingredients" rows="5" placeholder="e.g., 1 cup flour&#10;2 eggs"></textarea>
+      <label for="recipe-steps">Steps</label>
+      <textarea id="recipe-steps" rows="5" placeholder="Summarize the steps"></textarea>
+      <label for="recipe-tags">Tags (comma separated)</label>
+      <input type="text" id="recipe-tags" placeholder="e.g., dessert, breakfast">
+      <input type="hidden" id="extracted-image">
+      <label for="recipe-image">Recipe Image (optional)</label>
+      <input type="file" id="recipe-image" accept="image/*">
+      <button type="submit" class="btn-primary">Save Recipe</button>
+    </form>
+  </main>
+</body>
 </html>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1,34 +1,51 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Recipe Organizer – Home</title>
-    <link rel="stylesheet" href="styles.css" />
-  </head>
-  <body data-page="home">
-    <header>
-      <div class="header-content">
-        <h1><a href="home.html">Recipe Organizer</a></h1>
-        <nav class="nav-links">
-          <a href="add.html">Add Recipe</a>
-          <a href="view.html">View Recipes</a>
-        </nav>
-        <div class="user-info">
-          <span id="userDisplayName"></span>
-          <button id="logoutButton" class="logout">Log Out</button>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cocinando.Life</title>
+  <!-- Favicon -->
+  <link rel="icon" type="image/png" href="icon.png">
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <!-- Font Awesome for icons -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-xh6giXxmfC+NMPHreELfknX0tGkGBVf+7P0ahOq04hqkzOUl57BbSK1cwChXxvbLH+E5YhkoX+w1K7uKm2/j2w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script defer src="script.js"></script>
+</head>
+<body data-page="home">
+  <header>
+    <nav class="navbar">
+      <div class="nav-left">
+        <a href="index.html" class="brand">
+          <img src="icon.png" alt="Cocinando.Life logo" class="logo">
+          <span>Cocinando.Life</span>
+        </a>
+      </div>
+      <ul class="nav-links">
+        <li><a href="add.html" id="nav-add">Add Recipe</a></li>
+        <li><a href="view.html" id="nav-view">View Recipes</a></li>
+      </ul>
+      <div class="user-menu" id="user-menu">
+        <!-- Populated dynamically in script.js -->
+      </div>
+    </nav>
+  </header>
+
+  <main>
+    <!-- Redesigned hero section: full-width image with overlay content -->
+    <section class="home-hero">
+      <img src="hero.jpg" alt="Fresh salad" class="hero-img">
+      <div class="hero-overlay">
+        <h1>Let's get <span class="primary-text">cooking!</span></h1>
+        <p>Unleash your inner chef with these tried-and-tested recipes</p>
+        <div class="hero-buttons">
+          <a href="add.html" class="btn-primary">Add a Recipe</a>
+          <a href="view.html" class="btn-secondary">View Recipes</a>
         </div>
       </div>
-    </header>
-    <main class="container home-content">
-      <h2>Welcome to your recipe collection</h2>
-      <p>Choose what you’d like to do:</p>
-      <div class="home-options">
-        <a href="add.html" class="home-option">Add a Recipe</a>
-        <a href="view.html" class="home-option">View Recipes</a>
-      </div>
-    </main>
-    <script src="script.js"></script>
-  </body>
+    </section>
+  </main>
+</body>
 </html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -230,7 +230,9 @@
     }
     // Determine backend URL. Replace localhost with your deployed backend when needed.
     // Use deployed backend on Render. If running locally, you may adjust this URL.
-    const backendUrl = 'https://cocinando.onrender.com/extract';
+    const backendUrl = window.location.hostname === 'localhost'
+      ? 'http://localhost:5000/extract'
+      : 'https://cocinando.onrender.com/extract';
     fetch(backendUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Recreate `home.html` with full homepage content so the sign-in link is visible again
- Replace `dashboard.html` with the add-recipe UI to keep the extractor available at its old route
- Detect localhost in `script.js` and call the local extraction backend instead of the hosted service

## Testing
- `python -m py_compile backend/extract_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3e0e500088323a9ba7bcfb459aac5